### PR TITLE
Converting Jackson JsonParseException exception

### DIFF
--- a/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaConfig.java
+++ b/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaConfig.java
@@ -15,6 +15,7 @@ package com.unitvectory.jsonschema4springboot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.PathType;
 import com.networknt.schema.SchemaValidatorsConfig;
 
 /**
@@ -39,7 +40,11 @@ public interface ValidateJsonSchemaConfig {
      * @return the SchemaValidatorsConfig
      */
     default SchemaValidatorsConfig getSchemaValidatorsConfig() {
-        return new SchemaValidatorsConfig();
+        return new SchemaValidatorsConfig.Builder()
+                .pathType(PathType.LEGACY)
+                .errorMessageKeyword("message")
+                .nullableKeywordEnabled(true)
+                .build();
     }
 
     /**

--- a/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaException.java
+++ b/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaException.java
@@ -14,6 +14,8 @@
 package com.unitvectory.jsonschema4springboot;
 
 import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonParseException;
 import com.networknt.schema.ValidationMessage;
 import lombok.Getter;
 import lombok.NonNull;
@@ -39,5 +41,16 @@ public class ValidateJsonSchemaException extends RuntimeException {
     public ValidateJsonSchemaException(@NonNull Set<ValidationMessage> validationResult) {
         super("JSON did not validate against JSON Schema");
         this.validationResult = validationResult;
+    }
+
+    ValidateJsonSchemaException(@NonNull JsonParseException jsonParseException) {
+        super("JSON payload invalid an could not be parsed", jsonParseException);
+        String message = jsonParseException.getMessage();
+
+        if(message != null){
+            message = message.split("\n")[0];
+        }
+
+        this.validationResult = Set.of(ValidationMessage.builder().message(message).build());
     }
 }

--- a/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaException.java
+++ b/src/main/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaException.java
@@ -47,9 +47,9 @@ public class ValidateJsonSchemaException extends RuntimeException {
         super("JSON payload invalid an could not be parsed", jsonParseException);
         String message = jsonParseException.getMessage();
 
-        if(message != null){
-            message = message.split("\n")[0];
-        }
+        // This cannot be null, exception will default to "N/A" if message is not set
+        // We only want the first line as it contains the primary details
+        message = message.split("\n")[0];
 
         this.validationResult = Set.of(ValidationMessage.builder().message(message).build());
     }

--- a/src/test/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaArgumentResolverTest.java
+++ b/src/test/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaArgumentResolverTest.java
@@ -83,6 +83,48 @@ public class ValidateJsonSchemaArgumentResolverTest {
     }
 
     @Test
+    public void malformedJsonTest() throws Exception {
+
+        ValidateJsonSchemaArgumentResolver resolver = ValidateJsonSchemaArgumentResolver.newInstance();
+
+        ValidateJsonSchemaException thrown = assertThrows(ValidateJsonSchemaException.class,
+                () -> ArgumentResolverMockHelper.resolveArgument(resolver,
+                        ExampleValue.class, "{\"foo\"}",
+                        ValidateJsonSchemaVersion.V7,
+                        "classpath:schema/simpleschemaV7.json"),
+                "Expected ValidateJsonSchemaException exception");
+
+        assertEquals("JSON payload invalid an could not be parsed", thrown.getMessage());
+
+        assertEquals(1, thrown.getValidationResult().size());
+
+        ValidationMessage validationMessage = thrown.getValidationResult().iterator().next();
+        assertEquals("Unexpected character ('}' (code 125)): was expecting a colon to separate field name and value",
+                validationMessage.getMessage());
+    }
+
+    @Test
+    public void malformed2JsonTest() throws Exception {
+
+        ValidateJsonSchemaArgumentResolver resolver = ValidateJsonSchemaArgumentResolver.newInstance();
+
+        ValidateJsonSchemaException thrown = assertThrows(ValidateJsonSchemaException.class,
+                () -> ArgumentResolverMockHelper.resolveArgument(resolver,
+                        ExampleValue.class, "{\"foo\":\"b}",
+                        ValidateJsonSchemaVersion.V7,
+                        "classpath:schema/simpleschemaV7.json"),
+                "Expected ValidateJsonSchemaException exception");
+
+        assertEquals("JSON payload invalid an could not be parsed", thrown.getMessage());
+
+        assertEquals(1, thrown.getValidationResult().size());
+
+        ValidationMessage validationMessage = thrown.getValidationResult().iterator().next();
+        assertEquals("Unexpected end-of-input: was expecting closing quote for a string value",
+                validationMessage.getMessage());
+    }
+
+    @Test
     public void invalidJsonTest() throws Exception {
 
         ValidateJsonSchemaArgumentResolver resolver = ValidateJsonSchemaArgumentResolver.newInstance();

--- a/src/test/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaExceptionTest.java
+++ b/src/test/java/com/unitvectory/jsonschema4springboot/ValidateJsonSchemaExceptionTest.java
@@ -15,7 +15,13 @@ package com.unitvectory.jsonschema4springboot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.networknt.schema.ValidationMessage;
 
 /**
  * The ValidateJsonSchemaException test cases.
@@ -26,9 +32,19 @@ public class ValidateJsonSchemaExceptionTest {
 
     @Test
     public void nullValidationResultsTest() {
+        Set<ValidationMessage> validationResult = null;
         NullPointerException thrown = assertThrows(NullPointerException.class,
-                () -> new ValidateJsonSchemaException(null));
+                () -> new ValidateJsonSchemaException(validationResult));
 
         assertEquals("validationResult is marked non-null but is null", thrown.getMessage());
+    }
+
+    @Test
+    public void nullJsonParseExceptionTest() {
+        JsonParseException jsonParseException = null;
+        NullPointerException thrown = assertThrows(NullPointerException.class,
+                () -> new ValidateJsonSchemaException(jsonParseException));
+
+        assertEquals("jsonParseException is marked non-null but is null", thrown.getMessage());
     }
 }


### PR DESCRIPTION
In the case of a completely malformed JSON payload being submitted a JsonParseException was being thrown.  This change catches that exception and converts it into a ValidateJsonSchemaException exception which is more inline with the intent of how this library is intended to work.

This also fixes some of the deprecation warnings for methods that were using constructors to siwtch them to use builders.